### PR TITLE
fixed saving the user email in the login page

### DIFF
--- a/digital_receipt/lib/screens/login_screen.dart
+++ b/digital_receipt/lib/screens/login_screen.dart
@@ -4,7 +4,7 @@ import 'package:digital_receipt/screens/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:digital_receipt/widgets/loading.dart';
+import 'package:digital_receipt/services/shared_preference_service.dart';
 import 'package:digital_receipt/widgets/button_loading_indicator.dart';
 import 'package:wc_form_validators/wc_form_validators.dart';
 
@@ -25,8 +25,40 @@ class _LogInScreenState extends State<LogInScreen> {
   bool isLoading = false;
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  String _cachedEmailText;
+  Future<dynamic> _emailTextFuture;
+  Widget _futureEMAILText;
 
   ApiService _apiService = ApiService();
+  static SharedPreferenceService _sharedPreferenceService =
+      SharedPreferenceService();
+
+  @override
+  void initState() {
+    super.initState();
+    _emailTextFuture = _sharedPreferenceService.getStringValuesSF('EMAIL');
+
+    //This widget had to be built in the initState method to prevent rebuild
+    //when setState method is called when the user toggles the visisbility of the
+    //password field. This rebuild clears the text in the email field.
+    _futureEMAILText = FutureBuilder(
+      future: _emailTextFuture,
+      builder: (BuildContext context, AsyncSnapshot snapshot) {
+        Widget _emptywidget = _builldTextFormFiled('');
+        _cachedEmailText = snapshot.data == null ? ' ' : '${snapshot.data}';
+        Widget _dataWidget = _builldTextFormFiled(_cachedEmailText);
+
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return _emptywidget;
+        } else {
+          if (snapshot.hasError)
+            return _emptywidget;
+          else
+            return _dataWidget;
+        }
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -90,32 +122,7 @@ class _LogInScreenState extends State<LogInScreen> {
                   SizedBox(
                     height: 5,
                   ),
-                  TextFormField(
-                    controller: _emailController,
-                    validator: Validators.compose([
-                      Validators.required('Input Email Address'),
-                      Validators.email('Invalid Email Address'),
-                    ]),
-                    style: TextStyle(
-                      color: Color(0xFF2B2B2B),
-                      fontSize: 14,
-                      fontWeight: FontWeight.w600,
-                      fontFamily: 'Montserrat',
-                    ),
-                    keyboardType: TextInputType.emailAddress,
-                    decoration: InputDecoration(
-                      contentPadding: EdgeInsets.all(15),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(5),
-                        borderSide: BorderSide(
-                          color: Color(0xFFC8C8C8),
-                          width: 1,
-                        ),
-                      ),
-                      focusedBorder: OutlineInputBorder(),
-                      errorStyle: TextStyle(height: 0.5),
-                    ),
-                  ),
+                  _futureEMAILText,
                   SizedBox(
                     height: 20,
                   ),
@@ -211,8 +218,18 @@ class _LogInScreenState extends State<LogInScreen> {
                             isLoading = true;
                           });
 
+                          String emailString;
+                          if (_cachedEmailText != null) {
+                            if (_emailController.text.isNotEmpty)
+                              emailString = _emailController.text;
+                            else
+                              emailString = _cachedEmailText;
+                          } else {
+                            emailString = _emailController.text;
+                          }
+                          print(emailString);
                           String api_response = await _apiService.loginUser(
-                            _emailController.text,
+                            emailString,
                             _passwordController.text,
                           );
                           if (api_response == "true") {
@@ -430,6 +447,37 @@ class _LogInScreenState extends State<LogInScreen> {
               ),
             ),
             color: Colors.black),
+      ),
+    );
+  }
+
+  Widget _builldTextFormFiled(String text) {
+    WidgetsBinding.instance.addPostFrameCallback((_) => _emailController.text = text);
+    return TextFormField(
+      controller: _emailController,
+      validator: Validators.compose([
+        Validators.required('Input Email Address'),
+        Validators.email('Invalid Email Address'),
+      ]),
+      style: TextStyle(
+        color: Color(0xFF2B2B2B),
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        fontFamily: 'Montserrat',
+      ),
+      keyboardType: TextInputType.emailAddress,
+      decoration: InputDecoration(
+        hintText: text,
+        contentPadding: EdgeInsets.all(15),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(5),
+          borderSide: BorderSide(
+            color: Color(0xFFC8C8C8),
+            width: 1,
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(),
+        errorStyle: TextStyle(height: 0.5),
       ),
     );
   }


### PR DESCRIPTION
Issue Number - #182 

**What does this PR do?**

Retrieves and displays the user email to the email field in the login screen when an authenticated user wants to re-login

**description of Task to be completed?**

1. Retrieve the email of the authenticated user from shared preference.
2. Display it when a previously authenticated user opens the login page.
3. Displays nothing when an unauthenticated user opens the login page.

**How should this be manually tested?**
1. Login a user.
2. Log out the user.
3. Confirm that the user's email is already in the email field ready to be used to re-login.

