### PR TITLE
fixed functionality to get issued receipts from the database

### DIFF
--- a/digital_receipt/lib/services/api_service.dart
+++ b/digital_receipt/lib/services/api_service.dart
@@ -176,6 +176,41 @@ class ApiService {
     } */
   }
 
+  /// This function gets all issued receipts from the database.
+  Future getIssued() async {
+    (_dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
+        (HttpClient client) {
+      client.badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+      return client;
+    };
+
+   
+      String auth_token =
+          await _sharedPreferenceService.getStringValuesSF("AUTH_TOKEN");
+      Response response = await _dio.get(
+        "/business/receipt/issued",
+        options: Options(
+          followRedirects: false,
+          validateStatus: (status) {
+            return status < 500;
+          },
+          headers: {"token": auth_token},
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        var res = response.data["data"] as List;
+        print('res:::::: ${res.length}');
+        return res;
+      } else {
+        return null;
+      }
+   /*  } on DioError catch (error) {
+      print(error);
+    } */
+  }
+
   Future<String> signinUser(String email, String password, String name) async {
     var uri = '$_urlEndpoint/user/register';
     var response = await http.post(

--- a/digital_receipt/lib/services/api_service.dart
+++ b/digital_receipt/lib/services/api_service.dart
@@ -150,34 +150,33 @@ class ApiService {
       return client;
     };
 
-   
-      String auth_token =
-          await _sharedPreferenceService.getStringValuesSF("AUTH_TOKEN");
-      Response response = await _dio.get(
-        "/business/receipt/draft",
-        options: Options(
-          followRedirects: false,
-          validateStatus: (status) {
-            return status < 500;
-          },
-          headers: {"token": auth_token},
-        ),
-      );
+    String auth_token =
+        await _sharedPreferenceService.getStringValuesSF("AUTH_TOKEN");
+    Response response = await _dio.get(
+      "/business/receipt/draft",
+      options: Options(
+        followRedirects: false,
+        validateStatus: (status) {
+          return status < 500;
+        },
+        headers: {"token": auth_token},
+      ),
+    );
 
-      if (response.statusCode == 200) {
-        var res = response.data["data"] as List;
-        print('res:::::: ${res.length}');
-        return res;
-      } else {
-        return null;
-      }
-   /*  } on DioError catch (error) {
+    if (response.statusCode == 200) {
+      var res = response.data["data"] as List;
+      print('res:::::: ${res.length}');
+      return res;
+    } else {
+      return null;
+    }
+    /*  } on DioError catch (error) {
       print(error);
     } */
   }
 
   /// This function gets all issued receipts from the database.
-  Future getIssued() async {
+  Future<List<Receipt>> getIssued() async {
     (_dio.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate =
         (HttpClient client) {
       client.badCertificateCallback =
@@ -185,28 +184,35 @@ class ApiService {
       return client;
     };
 
-   
-      String auth_token =
-          await _sharedPreferenceService.getStringValuesSF("AUTH_TOKEN");
-      Response response = await _dio.get(
-        "/business/receipt/issued",
-        options: Options(
-          followRedirects: false,
-          validateStatus: (status) {
-            return status < 500;
-          },
-          headers: {"token": auth_token},
-        ),
-      );
+    String auth_token =
+        await _sharedPreferenceService.getStringValuesSF("AUTH_TOKEN");
+    Response response = await _dio.get(
+      "/business/receipt/issued",
+      options: Options(
+        followRedirects: false,
+        validateStatus: (status) {
+          return status < 500;
+        },
+        headers: {
+          "token": auth_token,
+              
+        },
+      ),
+    );
 
-      if (response.statusCode == 200) {
-        var res = response.data["data"] as List;
-        print('res:::::: ${res.length}');
-        return res;
-      } else {
-        return null;
-      }
-   /*  } on DioError catch (error) {
+    if (response.statusCode == 200) {
+      List<Receipt> issued_receipts = [];
+      response.data["data"].forEach((data) {
+        Receipt receipt = Receipt.fromJson(data);
+        issued_receipts.add(receipt);
+      });
+      // var res = response.data["data"] as List;
+      // print('res:::::: ${res.length}');
+      return issued_receipts;
+    } else {
+      return null;
+    }
+    /*  } on DioError catch (error) {
       print(error);
     } */
   }


### PR DESCRIPTION
Issue No: #97 
**What does this PR do?**

This PR implements the functionality to get issued requests from the database and display the gotten  data on the receipt history page.

**description of Task to be completed?**

1. Make a GET request to the api (https://hng-degeit-receipt.herokuapp.com/v1/business/receipt/issued) to get the issued request from the database.
2. Display the retrieved data on the receipt history page.

**How should this be manually tested?**
 Run the app,click on the receipt history page on the app drawer.
